### PR TITLE
Add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "Hermes Session Analyzer",
+  "install": "pnpm install --frozen-lockfile && python3 -m pip install --user --break-system-packages fastapi==0.141.1 uvicorn==0.52.3 httpx==0.28.1"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `.cursor/environment.json` so this repo is fully usable in Cursor Cloud Agents.

## What it sets up
The repo has two runnable surfaces:
- **JS side** — `prettier` formatting (`pnpm format` / `format:check`), pinned in the committed `pnpm-lock.yaml`.
- **Python backend** — `plugins/session-dashboard/dashboard/plugin_api.py`, a FastAPI router that reads the Hermes `state.db`. It `import`s `fastapi` at module load, so the dev environment installs `fastapi`/`uvicorn` (plus `httpx` for smoke tests) to run it standalone.

The Cursor default image already ships Node 22 + Python 3.12, so no custom Dockerfile is needed. No `start`/`terminals` process is defined because the repo has no standalone dev server — the backend normally mounts inside Hermes Desktop and is launched ad-hoc during development.

```json
{
  "name": "Hermes Session Analyzer",
  "install": "pnpm install --frozen-lockfile && python3 -m pip install --user --break-system-packages fastapi==0.141.1 uvicorn==0.52.3 httpx==0.28.1"
}
```

## Validation (this VM)
- `pnpm install --frozen-lockfile` → installs `prettier` from lockfile, no drift.
- `pnpm run format:check` → "All matched files use Prettier code style!"
- Ran the FastAPI backend under `uvicorn` against a synthetic `state.db` and exercised every route end to end: `/health`, `/sessions` (recent + `sort=failed` ranking with `failed_count`), `/sessions/{id}` (summary, tool breakdown, failure detection, files touched, subagent→child-session matching), `/search` (FTS trigram snippets), and 404 handling.
- `install.sh` validated against a fixture `config.yaml`: entry lands under `plugins.enabled`, idempotent across two runs, `checkpoints` block preserved.
- Install command run twice → idempotent.

[backend_e2e.log](https://cursor.com/agents/bc-306da002-4faa-4a5b-9bca-a9c99e53657d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbackend_e2e.log)

## Note
`AGENTS.md`'s supply-chain gate tools (`osv-gate`, `pkg-age-gate`, `sfw`) live under `~/.hermes/` (the end-user Hermes install) and are not present in the Cloud Agent VM, so those gates could not run here. The JS side adds nothing new (frozen lockfile); the Python packages are version-pinned and `fastapi` is already a runtime import of the backend.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-306da002-4faa-4a5b-9bca-a9c99e53657d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-306da002-4faa-4a5b-9bca-a9c99e53657d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

